### PR TITLE
IE 9 Error

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -14,7 +14,7 @@
 
     function insertNodeAt(fatherNode, node, position) {
       const refNode = (position ===0) ? fatherNode.children[0] : fatherNode.children[position-1].nextSibling
-      fatherNode.insertBefore(node, refNode)
+      fatherNode.insertBefore(node, typeof refNode == 'undefined' ? null : refNode)
     }
 
     function computeVmIndex(vnodes, element) {


### PR DESCRIPTION
IE 9 crashes if refNode is undefined.

Check if refNode is undefined and make it null, in this case IE 9 will not crash.